### PR TITLE
fix crashes on hypergraphs with only one module and module names withtout dots

### DIFF
--- a/de.cau.cs.se.software.evaluation.graph/src/de/cau/cs/se/software/evaluation/graph/transformation/VisualizationPlanarGraph.xtend
+++ b/de.cau.cs.se.software.evaluation.graph/src/de/cau/cs/se/software/evaluation/graph/transformation/VisualizationPlanarGraph.xtend
@@ -23,7 +23,10 @@ class VisualizationPlanarGraph implements IGenerator<ModularHypergraph, PlanarVi
 			} else
 				module.name
 			val separator = moduleQualifier.lastIndexOf('.')
-			node.name = moduleQualifier.substring(0,separator) 
+			if (separator == -1)
+				node.name = moduleQualifier
+			else
+				node.name = moduleQualifier.substring(0,separator)
 			node.context = moduleQualifier.substring(separator+1)
 			node.kind = module.kind
 			

--- a/de.cau.cs.se.software.evaluation/src/de/cau/cs/se/software/evaluation/transformation/metric/TransformationHyperedgesOnlyGraph.xtend
+++ b/de.cau.cs.se.software.evaluation/src/de/cau/cs/se/software/evaluation/transformation/metric/TransformationHyperedgesOnlyGraph.xtend
@@ -60,6 +60,11 @@ class TransformationHyperedgesOnlyGraph extends AbstractTransformation<Hypergrap
 	}
 	
 	override workEstimate(Hypergraph input) {
+		if (input.nodes.size == 0) {
+			println("Warning: hypergraph is empty")
+			return 1
+		}
+		
 		input.edges.size + input.nodes.map[it.edges.size].reduce[p1, p2| p1 + p2]
 	}
 

--- a/de.cau.cs.se.software.evaluation/src/de/cau/cs/se/software/evaluation/transformation/metric/TransformationHypergraphSize.xtend
+++ b/de.cau.cs.se.software.evaluation/src/de/cau/cs/se/software/evaluation/transformation/metric/TransformationHypergraphSize.xtend
@@ -162,6 +162,11 @@ class TransformationHypergraphSize extends AbstractTransformation<Hypergraph,Dou
 	}
 	
 	override workEstimate(Hypergraph input) {
+		if(input.nodes.size == 0) {
+			println("Warning: hypergraph is empty")
+			return 1
+		}
+		
 		input.edges.size + input.nodes.size + input.nodes.map[it.edges.size].reduce[p1, p2| p1 + p2] + // createSystemGraph
 		input.edges.size + input.nodes.size * input.nodes.size + input.nodes.size * input.nodes.size * input.edges.size // createRowPatternTable
 		input.nodes.size * input.nodes.size // calculateSize


### PR DESCRIPTION
TransformationHyperedgesOnlyGraph.xtend, TransformationHypergraphSize.xtend:
Please verify the return value of the work estimate. Without preventing this case (no nodes), the calculation triggers a nullpointer, as reduce returns null on empty input.